### PR TITLE
Add ycask fork on testnet at block 478989

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -106,8 +106,8 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nActivationHeight = 347500;
         consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nProtocolVersion = 170007;
         consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = 419200;
-        consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nProtocolVersion = 170009;
-        consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nActivationHeight =
+        consensus.vUpgrades[Consensus::UPGRADE_YCASH].nProtocolVersion = 170009;
+        consensus.vUpgrades[Consensus::UPGRADE_YCASH].nActivationHeight =
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
         // The best chain should have at least this much work.
@@ -272,6 +272,7 @@ public:
         consensus.nMajorityRejectBlockOutdated = 75;
         consensus.nMajorityWindow = 400;
         consensus.powLimit = uint256S("07ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        //consensus.powLimit = uint256S("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
         consensus.nPowAveragingWindow = 17;
         assert(maxUint/UintToArith256(consensus.powLimit) >= consensus.nPowAveragingWindow);
         consensus.nPowMaxAdjustDown = 32; // 32% adjustment down
@@ -288,9 +289,8 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nActivationHeight = 207500;
         consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nProtocolVersion = 170007;
         consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = 280000;
-        consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nProtocolVersion = 170008;
-        consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nActivationHeight =
-            Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_YCASH].nProtocolVersion = 270008;
+        consensus.vUpgrades[Consensus::UPGRADE_YCASH].nActivationHeight = 478989;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000000000001d0c4d9cd");
@@ -321,7 +321,7 @@ public:
         vSeeds.push_back(CDNSSeedData("z.cash", "dnsseed.testnet.z.cash")); // Zcash
 
         // guarantees the first 2 characters, when base58 encoded, are "tm"
-        base58Prefixes[PUBKEY_ADDRESS]     = {0x1D,0x25};
+        base58Prefixes[PUBKEY_ADDRESS]     = {0x1D,0x25}; // s - {0x20,0x28}; tm =  {0x1C,0x90};
         // guarantees the first 2 characters, when base58 encoded, are "t2"
         base58Prefixes[SCRIPT_ADDRESS]     = {0x1C,0xBA};
         // the first character, when base58 encoded, is "9" or "c" (as in Bitcoin)
@@ -330,7 +330,7 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY]     = {0x04,0x35,0x87,0xCF};
         base58Prefixes[EXT_SECRET_KEY]     = {0x04,0x35,0x83,0x94};
         // guarantees the first 2 characters, when base58 encoded, are "zt"
-        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x16,0xB6};
+        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x16,0xB6}; // zt - {0x16,0xB6}; yt - {0x15,0xB6}
         // guarantees the first 4 characters, when base58 encoded, are "ZiVt"
         base58Prefixes[ZCVIEWING_KEY]      = {0xA8,0xAC,0x0C};
         // guarantees the first 2 characters, when base58 encoded, are "ST"
@@ -422,8 +422,8 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nProtocolVersion = 170006;
         consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight =
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
-        consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nProtocolVersion = 170008;
-        consensus.vUpgrades[Consensus::UPGRADE_BLOSSOM].nActivationHeight =
+        consensus.vUpgrades[Consensus::UPGRADE_YCASH].nProtocolVersion = 170008;
+        consensus.vUpgrades[Consensus::UPGRADE_YCASH].nActivationHeight =
             Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
         // The best chain should have at least this much work.
@@ -568,4 +568,31 @@ std::string CChainParams::GetFoundersRewardAddressAtIndex(int i) const {
 void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)
 {
     regTestParams.UpdateNetworkUpgradeParameters(idx, nActivationHeight);
+}
+
+// To help debugging, let developers change the equihash parameters for a network upgrade.
+// TODO: Restrict this to regtest mode in the future.
+void UpdateEquihashUpgradeParameters(Consensus::UpgradeIndex idx, unsigned int n, unsigned int k)
+{
+    assert(idx > Consensus::BASE_SPROUT && idx < Consensus::MAX_NETWORK_UPGRADES);
+    EquihashUpgradeInfo[idx].N = n;
+    EquihashUpgradeInfo[idx].K = k;
+}
+
+// Return Equihash parameter N at a given block height.
+unsigned int CChainParams::EquihashN(int nHeight) const {
+    unsigned int n = EquihashUpgradeInfo[CurrentEpoch(nHeight, GetConsensus())].N;
+    if (n == EquihashInfo::DEFAULT_PARAMS) {
+        n = nEquihashN;
+    }
+    return n;
+}
+
+// Return Equihash parameter K at a given block height.
+unsigned int CChainParams::EquihashK(int nHeight) const {
+    unsigned int k = EquihashUpgradeInfo[CurrentEpoch(nHeight, GetConsensus())].K;
+    if (k == EquihashInfo::DEFAULT_PARAMS) {
+        k = nEquihashK;
+    }
+    return k;
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -83,8 +83,10 @@ public:
     /** Policy: Filter transactions that do not match well-defined patterns */
     bool RequireStandard() const { return fRequireStandard; }
     int64_t PruneAfterHeight() const { return nPruneAfterHeight; }
-    unsigned int EquihashN() const { return nEquihashN; }
-    unsigned int EquihashK() const { return nEquihashK; }
+    
+    unsigned int EquihashN(int nHeight = 0) const;
+    unsigned int EquihashK(int nHeight = 0) const;
+
     std::string CurrencyUnits() const { return strCurrencyUnits; }
     uint32_t BIP44CoinType() const { return bip44CoinType; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
@@ -159,5 +161,10 @@ bool SelectParamsFromCommandLine();
  * Allows modifying the network upgrade regtest parameters.
  */
 void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight);
+
+/**
+ * Let developers modify the equihash upgrade parameters for testing purposes.
+ */
+void UpdateEquihashUpgradeParameters(Consensus::UpgradeIndex idx, unsigned int n, unsigned int k);
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -26,7 +26,7 @@ enum UpgradeIndex {
     UPGRADE_TESTDUMMY,
     UPGRADE_OVERWINTER,
     UPGRADE_SAPLING,
-    UPGRADE_BLOSSOM,
+    UPGRADE_YCASH,
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp
     MAX_NETWORK_UPGRADES
 };

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -30,13 +30,49 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
         /*.strInfo =*/ "See https://z.cash/upgrade/sapling.html for details.",
     },
     {
-        /*.nBranchId =*/ 0x2bb40e60,
-        /*.strName =*/ "Blossom",
-        /*.strInfo =*/ "See https://z.cash/upgrade/blossom.html for details.",
+        /*.nBranchId =*/ 0x4bb40e60,
+        /*.strName =*/ "YCash",
+        /*.strInfo =*/ "See YCash for details.",
     }
 };
 
 const uint32_t SPROUT_BRANCH_ID = NetworkUpgradeInfo[Consensus::BASE_SPROUT].nBranchId;
+
+
+/**
+ * General information associating epoch with equihash parameters.
+ * Ordered by Consensus::UpgradeIndex, to match NetworkUpgradeInfo.
+ * TODO: Maybe refactor and include in NetworkUpgradeInfo
+ * TODO: Make this const
+ */
+struct EquihashInfo EquihashUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
+    // BASE_SPROUT
+    {
+        /* N = */ EquihashInfo::DEFAULT_PARAMS,
+        /* K = */ EquihashInfo::DEFAULT_PARAMS,
+    },
+    // UPGRADE_TESTDUMMY
+    {
+        /* N = */ EquihashInfo::DEFAULT_PARAMS,
+        /* K = */ EquihashInfo::DEFAULT_PARAMS,
+    },
+    //  UPGRADE_OVERWINTER
+    {
+        /* N = */ EquihashInfo::DEFAULT_PARAMS,
+        /* K = */ EquihashInfo::DEFAULT_PARAMS,
+    },
+    // UPGRADE SAPLING
+    {
+        /* N = */ EquihashInfo::DEFAULT_PARAMS,
+        /* K = */ EquihashInfo::DEFAULT_PARAMS,
+    },
+    // UPGRADE YCASH
+    {
+        // TODO (A): Finalize Equihash params
+        /* N = */ 96,
+        /* K = */  5,
+    }
+};
 
 UpgradeState NetworkUpgradeState(
     int nHeight,

--- a/src/consensus/upgrades.h
+++ b/src/consensus/upgrades.h
@@ -29,6 +29,19 @@ extern const struct NUInfo NetworkUpgradeInfo[];
 // Consensus branch id to identify pre-overwinter (Sprout) consensus rules.
 extern const uint32_t SPROUT_BRANCH_ID;
 
+
+struct EquihashInfo {
+    unsigned int N;
+    unsigned int K;
+
+    // Use default value as set in chainparams and genesis block
+    static constexpr int DEFAULT_PARAMS = 0;
+};
+
+extern struct EquihashInfo EquihashUpgradeInfo[];
+
+
+
 /**
  * Checks the state of a given network upgrade based on block height.
  * Caller must check that the height is >= 0 (and handle unknown heights).

--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -814,3 +814,16 @@ template bool Equihash<48,5>::OptimisedSolve(const eh_HashState& base_state,
                                              const std::function<bool(EhSolverCancelCheck)> cancelled);
 #endif
 template bool Equihash<48,5>::IsValidSolution(const eh_HashState& base_state, std::vector<unsigned char> soln);
+
+
+// Explicit instantiations for Equihash<144,5>
+template int Equihash<144,5>::InitialiseState(eh_HashState& base_state);
+#ifdef ENABLE_MINING
+template bool Equihash<144,5>::BasicSolve(const eh_HashState& base_state,
+                                         const std::function<bool(std::vector<unsigned char>)> validBlock,
+                                         const std::function<bool(EhSolverCancelCheck)> cancelled);
+template bool Equihash<144,5>::OptimisedSolve(const eh_HashState& base_state,
+                                             const std::function<bool(std::vector<unsigned char>)> validBlock,
+                                             const std::function<bool(EhSolverCancelCheck)> cancelled);
+#endif
+template bool Equihash<144,5>::IsValidSolution(const eh_HashState& base_state, std::vector<unsigned char> soln);

--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -199,6 +199,7 @@ static Equihash<96,3> Eh96_3;
 static Equihash<200,9> Eh200_9;
 static Equihash<96,5> Eh96_5;
 static Equihash<48,5> Eh48_5;
+static Equihash<144,5> Eh144_5;
 
 #define EhInitialiseState(n, k, base_state)  \
     if (n == 96 && k == 3) {                 \
@@ -209,6 +210,8 @@ static Equihash<48,5> Eh48_5;
         Eh96_5.InitialiseState(base_state);  \
     } else if (n == 48 && k == 5) {          \
         Eh48_5.InitialiseState(base_state);  \
+    } else if (n == 144 && k == 5) {         \
+        Eh144_5.InitialiseState(base_state); \
     } else {                                 \
         throw std::invalid_argument("Unsupported Equihash parameters"); \
     }
@@ -226,6 +229,8 @@ inline bool EhBasicSolve(unsigned int n, unsigned int k, const eh_HashState& bas
         return Eh96_5.BasicSolve(base_state, validBlock, cancelled);
     } else if (n == 48 && k == 5) {
         return Eh48_5.BasicSolve(base_state, validBlock, cancelled);
+    } else if (n == 144 && k == 5) {
+        return Eh144_5.BasicSolve(base_state, validBlock, cancelled);
     } else {
         throw std::invalid_argument("Unsupported Equihash parameters");
     }
@@ -250,6 +255,8 @@ inline bool EhOptimisedSolve(unsigned int n, unsigned int k, const eh_HashState&
         return Eh96_5.OptimisedSolve(base_state, validBlock, cancelled);
     } else if (n == 48 && k == 5) {
         return Eh48_5.OptimisedSolve(base_state, validBlock, cancelled);
+    } else if (n == 144 && k == 5) {
+        return Eh144_5.OptimisedSolve(base_state, validBlock, cancelled);
     } else {
         throw std::invalid_argument("Unsupported Equihash parameters");
     }
@@ -272,6 +279,8 @@ inline bool EhOptimisedSolveUncancellable(unsigned int n, unsigned int k, const 
         ret = Eh96_5.IsValidSolution(base_state, soln);  \
     } else if (n == 48 && k == 5) {                      \
         ret = Eh48_5.IsValidSolution(base_state, soln);  \
+    } else if (n == 144 && k == 5) {                      \
+        ret = Eh144_5.IsValidSolution(base_state, soln);  \
     } else {                                             \
         throw std::invalid_argument("Unsupported Equihash parameters"); \
     }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -16,6 +16,17 @@
 
 #include "sodium.h"
 
+unsigned int ReduceDifficultyBy(const CBlockIndex* pindexLast, int64_t multiplier, const Consensus::Params& params) {
+    arith_uint256 target;
+    target.SetCompact(pindexLast->nBits);
+    target *= multiplier;
+    const arith_uint256 pow_limit = UintToArith256(params.powLimit);
+    if (target > pow_limit) {
+        target = pow_limit;
+    }
+    return target.GetCompact();
+}
+
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
@@ -23,6 +34,15 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     // Genesis block
     if (pindexLast == NULL)
         return nProofOfWorkLimit;
+
+    int nHeight = pindexLast->nHeight + 1;
+
+    // TODO(A): Fix the constants and make the POW limit a multiplier of the current one. 
+    if (nHeight >= params.vUpgrades[Consensus::UPGRADE_YCASH].nActivationHeight && 
+            nHeight <= params.vUpgrades[Consensus::UPGRADE_YCASH].nActivationHeight + 5) {
+        LogPrintStr("Returned a reduced PoW limit\n");
+        return nProofOfWorkLimit;
+    }
 
     {
         // Comparing to pindexLast->nHeight with >= because this function
@@ -93,8 +113,26 @@ unsigned int CalculateNextWorkRequired(arith_uint256 bnAvg,
 
 bool CheckEquihashSolution(const CBlockHeader *pblock, const CChainParams& params)
 {
-    unsigned int n = params.EquihashN();
-    unsigned int k = params.EquihashK();
+    // Derive n, k from the solution size as the block header does not specify parameters used.
+    // In the future, we could pass in the block height and call EquihashN() and EquihashK()
+    // to perform a contextual check against the parameters in use at a given block height.
+    unsigned int n, k;
+    size_t nSolSize = pblock->nSolution.size();
+    if (nSolSize == 1344) { // mainnet and testnet genesis
+        n = 200;
+        k = 9;
+    } else if (nSolSize == 36) { // regtest genesis
+        n = 48;
+        k = 5;
+    } else if (nSolSize == 100) {
+        n = 144;
+        k = 5;
+    } else if (nSolSize == 68) {
+        n = 96;
+        k = 5;
+    } else {
+        return error("%s: Unsupported solution size of %d", __func__, nSolSize);
+    }
 
     // Hash state
     crypto_generichash_blake2b_state state;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -195,10 +195,12 @@ UniValue generate(const UniValue& params, bool fHelp)
     }
     unsigned int nExtraNonce = 0;
     UniValue blockHashes(UniValue::VARR);
-    unsigned int n = Params().EquihashN();
-    unsigned int k = Params().EquihashK();
+    
     while (nHeight < nHeightEnd)
     {
+        unsigned int n = Params().EquihashN(nHeight + 1);
+        unsigned int k = Params().EquihashK(nHeight + 1);
+
         std::unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(coinbaseScript->reserveScript));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 170007;
+static const int PROTOCOL_VERSION = 270008;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -366,11 +366,16 @@ UniValue getaddressesbyaccount(const UniValue& params, bool fHelp)
 
     // Find all addresses that have the given account
     UniValue ret(UniValue::VARR);
+    LogPrintf("AddresBook size: %d\n", pwalletMain->mapAddressBook.size());
     for (const std::pair<CTxDestination, CAddressBookData>& item : pwalletMain->mapAddressBook) {
         const CTxDestination& dest = item.first;
         const std::string& strName = item.second.name;
         if (strName == strAccount) {
-            ret.push_back(EncodeDestination(dest));
+            std::string enc = EncodeDestination(dest);
+            LogPrintStr("Encoded addr:" + enc + "\n");
+            ret.push_back(enc);
+        } else {
+            LogPrintStr("Skipping because account mismatch:" + strName + ":" + strAccount);
         }
     }
     return ret;


### PR DESCRIPTION
Add support for ycash fork on Testnet
 - Add a "ycash" network upgrade
 - Bump protocol version so that we can disconnect from zcash network after fork
 - Add nuparams on regtest
 - Add a testnet block number for the fork
 - Add support for readjusting the difficulty at fork block