### PR TITLE
Set deprecation height to 2,275,000

### DIFF
--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -10,7 +10,7 @@
 // * Shut down 14 weeks' worth of blocks after the estimated release block height.
 // * A warning is shown during the 2 weeks' worth of blocks prior to shut down.
 static const int APPROX_RELEASE_HEIGHT = 1084000;
-static const int DEPRECATION_HEIGHT = 1600000;
+static const int DEPRECATION_HEIGHT = 2275000;
 // static const int WEEKS_UNTIL_DEPRECATION = 14;
 // static const int DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 48);
 


### PR DESCRIPTION
2,275,000 is 5,000 blocks before the second halving at 2,280,000.

